### PR TITLE
Update iyzipay.postman_collection

### DIFF
--- a/iyzipay.postman_collection
+++ b/iyzipay.postman_collection
@@ -39,15 +39,6 @@
 									"var apiKey = globals.apiKey",
 									"var secretKey = globals.secretKey",
 									"",
-									"//import crypto-js sha1",
-									"$.getScript(\"https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/sha1.min.js\",",
-									"function()",
-									"{});",
-									"//import crypto-js base64",
-									"$.getScript(\"https://cdnjs.cloudflare.com/ajax/libs/crypto-js/3.1.9-1/enc-base64.min.js\",",
-									"function()",
-									"{});",
-									"",
 									"var approval = {",
 									"    locale: null,",
 									"    conversationId: null,",
@@ -8720,6 +8711,7 @@
 						"exec": [
 							"postman.setGlobalVariable('apiKey',\"\");",
 							"postman.setGlobalVariable('secretKey',\"\");",
+							"postman.setGlobalVariable('CryptoJS',\"require('crypto-js')\");",
 							""
 						]
 					}


### PR DESCRIPTION
Solution for Reference Error :$
With the release of v4.5.0+ of the Postman Mac app and Newman v3, jQuery was discontinued as a built-in library in the scripting sandbox. Source  https://blog.postman.com/jquery-replaced-by-cheeriojs-in-postman-sandbox/
Suggested changes applied. Source : https://github.com/iyzico/iyzipay-postman/issues/2
-JQuery style import statement removed, global variable added for CryptoJS